### PR TITLE
feat: throw unless platform is macOS

### DIFF
--- a/app/clipboard.py
+++ b/app/clipboard.py
@@ -1,4 +1,9 @@
 # mac_clipboard_monitor.py
+import platform
+# TODO: Add support for Windows and Linux
+if platform.system() != "Darwin":
+    raise ImportError("This module only supports macOS")
+
 import time
 import io
 import AppKit


### PR DESCRIPTION
### TL;DR

Added platform check to ensure clipboard module only runs on macOS.

### What changed?

- Added import for the `platform` module
- Added a check that raises an `ImportError` if the system is not macOS
- Added a TODO comment to track future support for Windows and Linux

### How to test?

1. Run the application on a macOS system to verify it works normally
2. If possible, try running on a non-macOS system to confirm the appropriate error is raised

### Why make this change?

The clipboard functionality is currently only implemented for macOS. This change prevents the application from silently failing on other operating systems by providing a clear error message, while also documenting the need for cross-platform support in the future.