### PR TITLE
feat: parsing response to only be clipboard info

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,11 +4,23 @@ from audio import HotwordListener
 from clipboard import ClipboardMonitor
 import time
 import os
+import instructor
+from pydantic import BaseModel
 
 groq_client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+groq_client = instructor.from_provider(
+    "groq/gpt-oss-20b", api_key=os.getenv("GROQ_API_KEY")
+)
 
 monitor = ClipboardMonitor()
 monitor.start(log=True)
+
+
+class ClipboardContent(BaseModel):
+    """Structured response containing only the content to be copied to clipboard."""
+
+    content_for_clipboard: str
+
 
 def on_hotword_detected(text, audio):
     prompt = f"Voice Command: {text}"
@@ -17,20 +29,27 @@ def on_hotword_detected(text, audio):
     prompt += f"{monitor.get_last()}"
 
     chat_completion = groq_client.chat.completions.create(
-    model="openai/gpt-oss-20b",  # or another available Groq model
-    messages=[
-            {"role": "system", "content": "You are a helpful assistant responding to voice commands managing someone's clipboard."},
-            {"role": "user", "content": prompt}
+        model="openai/gpt-oss-20b",  # or another available Groq model
+        response_model=ClipboardContent,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a helpful assistant responding to voice commands managing someone's clipboard.",
+            },
+            {"role": "user", "content": prompt},
         ],
     )
 
-    response = chat_completion.choices[0].message.content
+    # response = chat_completion.choices[0].message.content
+    print(f"Full Groq response: {chat_completion}")
+    response = chat_completion.content_for_clipboard
     print(f"Groq response: {response}")
+    # use instructor to remove fluff so response is only the text to copy to clipboard
     monitor.copy_text(response)
     print("Clipboard updated with Groq response.")
 
-    
     # Here you can add more actions, e.g., interact with clipboard or other functionalities
+
 
 if __name__ == "__main__":
     listener = HotwordListener("tango", on_hotword_detected)


### PR DESCRIPTION
### TL;DR

Integrated the Instructor library with Groq to improve clipboard content handling using structured responses.

### What changed?

- Added the Instructor library to enhance Groq client functionality
- Created a `ClipboardContent` Pydantic model to structure the AI responses
- Modified the Groq client initialization to use Instructor's `from_provider` method
- Updated the chat completion call to use the new response model
- Changed the response handling to extract only the content intended for the clipboard
- Added debug printing of the full Groq response

### How to test?

1. Ensure the `instructor` package is installed
2. Set the `GROQ_API_KEY` environment variable
3. Run the application and trigger a voice command
4. Verify that the clipboard is updated with clean, structured content
5. Check the console logs to see both the full response and the extracted clipboard content

### Why make this change?

This change improves the quality of clipboard content by using structured responses through Instructor. By defining a specific Pydantic model for clipboard content, we ensure that only the relevant text is copied to the clipboard without any additional formatting or explanatory text that the AI might include. This creates a more seamless user experience when using voice commands to manipulate clipboard content.